### PR TITLE
Corregir error al retornar tipo Any en fib.ts

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-module.exports = function fibonacci(n:number):number{
+export default function fibonacci(n:number):number{
   if (n < 0) {
     return -1;
   } else if (n == 0) {
@@ -9,4 +9,4 @@ module.exports = function fibonacci(n:number):number{
   }
 
   return fibonacci(n - 1) + fibonacci(n - 2);
-};
+}

--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-module.exports = function fibonacci(n) {
+module.exports = function fibonacci(n:number):number{
   if (n < 0) {
     return -1;
   } else if (n == 0) {

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,6 +1,6 @@
 // Endpoint for querying the fibonacci numbers
 
-const fibonacci = require("./fib");
+import fibonacci from "./fib";
 
 export default (req, res) => {
   const { num } = req.params;
@@ -13,4 +13,4 @@ export default (req, res) => {
   }
 
   res.send(result);
-};
+}


### PR DESCRIPTION
Para asegurar la correctitud del programa, nos apoyamos en una extensión de ESLint en nuestro editor de texto (en este caso VSCode) para ubicar los problemas de forma local. Seguidamente, verificamos que era un error respecto al tipo de dato que recibía la función, por lo que el único cambio fue agregar el tipo indicado para la variable "n", el cual es number.